### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Depends:
     R (>= 3.4.0)
 Imports: 
     methods,
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
     rstantools (>= 2.1.1),
@@ -39,8 +39,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 Suggests:
     rmarkdown,
     knitr,

--- a/inst/stan/horseshoe_MA.stan
+++ b/inst/stan/horseshoe_MA.stan
@@ -32,7 +32,7 @@ data {
   // data for group-level effects of ID 1
   int<lower=1> N_1;  // number of grouping levels
   int<lower=1> M_1;  // number of coefficients per level
-  int<lower=1> J_1[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_1;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_1_1;
   int prior_only;  // should the likelihood be ignored?
@@ -48,7 +48,7 @@ parameters {
   real<lower=0> hs_global;  // global shrinkage parameters
   real<lower=0> hs_slab;  // slab regularization parameter
   vector<lower=0>[M_1] sd_1;  // group-level standard deviations
-  vector[N_1] z_1[M_1];  // standardized group-level effects
+  array[M_1] vector[N_1] z_1;  // standardized group-level effects
 }
 transformed parameters {
   vector[K] b;  // population-level effects

--- a/inst/stan/horseshoe_MA_ml.stan
+++ b/inst/stan/horseshoe_MA_ml.stan
@@ -32,13 +32,13 @@ data {
   // data for group-level effects of ID 1
   int<lower=1> N_1;  // number of grouping levels
   int<lower=1> M_1;  // number of coefficients per level
-  int<lower=1> J_1[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_1;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_1_1;
   // data for group-level effects of ID 2
   int<lower=1> N_2;  // number of grouping levels
   int<lower=1> M_2;  // number of coefficients per level
-  int<lower=1> J_2[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_2;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_2_1;
   int prior_only;  // should the likelihood be ignored?
@@ -54,9 +54,9 @@ parameters {
   real<lower=0> hs_global;  // global shrinkage parameters
   real<lower=0> hs_slab;  // slab regularization parameter
   vector<lower=0>[M_1] sd_1;  // group-level standard deviations
-  vector[N_1] z_1[M_1];  // standardized group-level effects
+  array[M_1] vector[N_1] z_1;  // standardized group-level effects
   vector<lower=0>[M_2] sd_2;  // group-level standard deviations
-  vector[N_2] z_2[M_2];  // standardized group-level effects
+  array[M_2] vector[N_2] z_2;  // standardized group-level effects
 }
 transformed parameters {
   vector[K] b;  // population-level effects

--- a/inst/stan/horseshoe_MA_ml_noint.stan
+++ b/inst/stan/horseshoe_MA_ml_noint.stan
@@ -32,13 +32,13 @@ data {
   // data for group-level effects of ID 1
   int<lower=1> N_1;  // number of grouping levels
   int<lower=1> M_1;  // number of coefficients per level
-  int<lower=1> J_1[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_1;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_1_1;
   // data for group-level effects of ID 2
   int<lower=1> N_2;  // number of grouping levels
   int<lower=1> M_2;  // number of coefficients per level
-  int<lower=1> J_2[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_2;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_2_1;
   int prior_only;  // should the likelihood be ignored?
@@ -54,9 +54,9 @@ parameters {
   real<lower=0> hs_global;  // global shrinkage parameters
   real<lower=0> hs_slab;  // slab regularization parameter
   vector<lower=0>[M_1] sd_1;  // group-level standard deviations
-  vector[N_1] z_1[M_1];  // standardized group-level effects
+  array[M_1] vector[N_1] z_1;  // standardized group-level effects
   vector<lower=0>[M_2] sd_2;  // group-level standard deviations
-  vector[N_2] z_2[M_2];  // standardized group-level effects
+  array[M_2] vector[N_2] z_2;  // standardized group-level effects
 }
 transformed parameters {
   vector[K] b;  // population-level effects

--- a/inst/stan/horseshoe_MA_noint.stan
+++ b/inst/stan/horseshoe_MA_noint.stan
@@ -32,7 +32,7 @@ data {
   // data for group-level effects of ID 1
   int<lower=1> N_1;  // number of grouping levels
   int<lower=1> M_1;  // number of coefficients per level
-  int<lower=1> J_1[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_1;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_1_1;
   int prior_only;  // should the likelihood be ignored?
@@ -48,7 +48,7 @@ parameters {
   real<lower=0> hs_global;  // global shrinkage parameters
   real<lower=0> hs_slab;  // slab regularization parameter
   vector<lower=0>[M_1] sd_1;  // group-level standard deviations
-  vector[N_1] z_1[M_1];  // standardized group-level effects
+  array[M_1] vector[N_1] z_1;  // standardized group-level effects
 }
 transformed parameters {
   vector[K] b;  // population-level effects

--- a/inst/stan/lasso_MA.stan
+++ b/inst/stan/lasso_MA.stan
@@ -13,7 +13,7 @@ data {
   // data for group-level effects of ID 1
   int<lower=1> N_1;  // number of grouping levels
   int<lower=1> M_1;  // number of coefficients per level
-  int<lower=1> J_1[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_1;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_1_1;
   int prior_only;  // should the likelihood be ignored?
@@ -26,7 +26,7 @@ parameters {
   // lasso shrinkage parameter
   real<lower=0> lasso_inv_lambda;
   vector<lower=0>[M_1] sd_1;  // group-level standard deviations
-  vector[N_1] z_1[M_1];  // standardized group-level effects
+  array[M_1] vector[N_1] z_1;  // standardized group-level effects
 }
 transformed parameters {
   real<lower=0> sigma = 0;  // residual SD

--- a/inst/stan/lasso_MA_ml.stan
+++ b/inst/stan/lasso_MA_ml.stan
@@ -29,13 +29,13 @@ data {
   // data for group-level effects of ID 1
   int<lower=1> N_1;  // number of grouping levels
   int<lower=1> M_1;  // number of coefficients per level
-  int<lower=1> J_1[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_1;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_1_1;
   // data for group-level effects of ID 2
   int<lower=1> N_2;  // number of grouping levels
   int<lower=1> M_2;  // number of coefficients per level
-  int<lower=1> J_2[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_2;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_2_1;
   int prior_only;  // should the likelihood be ignored?
@@ -49,9 +49,9 @@ parameters {
   real<lower=0> lasso_inv_lambda;
   //Standard deviations
   vector<lower=0>[M_1] sd_1;  // group-level standard deviations
-  vector[N_1] z_1[M_1];  // standardized group-level effects
+  array[M_1] vector[N_1] z_1;  // standardized group-level effects
   vector<lower=0>[M_2] sd_2;  // group-level standard deviations
-  vector[N_2] z_2[M_2];  // standardized group-level effects
+  array[M_2] vector[N_2] z_2;  // standardized group-level effects
 }
 transformed parameters {
   vector[N_1] r_1_1;  // actual group-level effects

--- a/inst/stan/lasso_MA_ml_noint.stan
+++ b/inst/stan/lasso_MA_ml_noint.stan
@@ -29,13 +29,13 @@ data {
   // data for group-level effects of ID 1
   int<lower=1> N_1;  // number of grouping levels
   int<lower=1> M_1;  // number of coefficients per level
-  int<lower=1> J_1[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_1;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_1_1;
   // data for group-level effects of ID 2
   int<lower=1> N_2;  // number of grouping levels
   int<lower=1> M_2;  // number of coefficients per level
-  int<lower=1> J_2[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_2;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_2_1;
   int prior_only;  // should the likelihood be ignored?
@@ -48,9 +48,9 @@ parameters {
   real<lower=0> lasso_inv_lambda;
   //Standard deviations
   vector<lower=0>[M_1] sd_1;  // group-level standard deviations
-  vector[N_1] z_1[M_1];  // standardized group-level effects
+  array[M_1] vector[N_1] z_1;  // standardized group-level effects
   vector<lower=0>[M_2] sd_2;  // group-level standard deviations
-  vector[N_2] z_2[M_2];  // standardized group-level effects
+  array[M_2] vector[N_2] z_2;  // standardized group-level effects
 }
 transformed parameters {
   vector[N_1] r_1_1;  // actual group-level effects

--- a/inst/stan/lasso_MA_noint.stan
+++ b/inst/stan/lasso_MA_noint.stan
@@ -13,7 +13,7 @@ data {
   // data for group-level effects of ID 1
   int<lower=1> N_1;  // number of grouping levels
   int<lower=1> M_1;  // number of coefficients per level
-  int<lower=1> J_1[N];  // grouping indicator per observation
+  array[N] int<lower=1> J_1;  // grouping indicator per observation
   // group-level predictor values
   vector[N] Z_1_1;
   int prior_only;  // should the likelihood be ignored?
@@ -25,7 +25,7 @@ parameters {
   // lasso shrinkage parameter
   real<lower=0> lasso_inv_lambda;
   vector<lower=0>[M_1] sd_1;  // group-level standard deviations
-  vector[N_1] z_1[M_1];  // standardized group-level effects
+  array[M_1] vector[N_1] z_1;  // standardized group-level effects
 }
 transformed parameters {
   real<lower=0> sigma = 0;  // residual SD


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
